### PR TITLE
switch to ascii arrow characters

### DIFF
--- a/src/HashBus.View.UserLeaderboard/Program.cs
+++ b/src/HashBus.View.UserLeaderboard/Program.cs
@@ -16,9 +16,9 @@ namespace HashBus.Projection.UserLeaderboard
         private static readonly Dictionary<int, string> movementTokens =
             new Dictionary<int, string>
             {
-                { -1, "↑" },
-                { 0, "→" },
-                { 1, "↓" },
+                { -1, "^" },
+                { 0, "=" },
+                { 1, "v" },
             };
 
         private static readonly Dictionary<int, ConsoleColor> movementColors =


### PR DESCRIPTION
fixes #22

I tried to find the cause but I gave up. I'm not sure if it's .NET 4.6 or Windows 10 that causes the problem.
