### PR TITLE
Fixes the link to the monitored hashtag

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<body>
 		<header class="site-header">
             <h1 class="site-title">
-                Leaderboard <a href="https://twitter.com/hashtag/BuildStuffUA">#{{ title }}</a>
+                Leaderboard <a ng-href="https://twitter.com/hashtag/{{ title }}">#{{ title }}</a>
             </h1>
             <a class="powered-by" href="http://particular.net"><span></span>Powered by Particular Software</a>
 		</header>


### PR DESCRIPTION
The link in the leaderboard header was wrong and hardcoded, moved to a dynamic link using `ng-href`.

@Particular/hashbus-committers please review