### PR TITLE
added ignoring of staff to web API

### DIFF
--- a/src/HashBus.WebApi/HashBus.WebApi.csproj
+++ b/src/HashBus.WebApi/HashBus.WebApi.csproj
@@ -75,6 +75,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IEntry.cs" />
+    <Compile Include="IgnoredUserNamesService.cs" />
+    <Compile Include="IIgnoredUserNamesService.cs" />
     <Compile Include="Leaderboard.cs" />
     <Compile Include="MostHashtaggedModule.cs" />
     <Compile Include="MostRetweetedModule.cs" />

--- a/src/HashBus.WebApi/IIgnoredUserNamesService.cs
+++ b/src/HashBus.WebApi/IIgnoredUserNamesService.cs
@@ -1,0 +1,9 @@
+﻿namespace HashBus.WebApi
+{
+    using System.Collections.Generic;
+
+    public interface IIgnoredUserNamesService
+    {
+        IReadOnlyList<string> Get();
+    }
+}

--- a/src/HashBus.WebApi/IgnoredUserNamesService.cs
+++ b/src/HashBus.WebApi/IgnoredUserNamesService.cs
@@ -1,0 +1,26 @@
+﻿namespace HashBus.WebApi
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using LiteGuard;
+
+    class IgnoredUserNamesService : IIgnoredUserNamesService
+    {
+        private readonly List<string> ignoredUserNames;
+
+        public IgnoredUserNamesService(IEnumerable<string> ignoredUserNames)
+        {
+            Guard.AgainstNullArgument(nameof(ignoredUserNames), ignoredUserNames);
+
+            this.ignoredUserNames = ignoredUserNames.ToList();
+        }
+
+        public IReadOnlyList<string> Get()
+        {
+            return this.ignoredUserNames.ToList();
+        }
+    }
+}

--- a/src/HashBus.WebApi/MostMentionedModule.cs
+++ b/src/HashBus.WebApi/MostMentionedModule.cs
@@ -7,7 +7,8 @@
 
     public class MostMentionedModule : NancyModule
     {
-        public MostMentionedModule(IRepository<string, IEnumerable<Mention>> mentions)
+        public MostMentionedModule(
+            IRepository<string, IEnumerable<Mention>> mentions, IIgnoredUserNamesService ignoredUserNamesService)
         {
             this.Get["/most-mentioned/{track}", true] = async (parameters, __) =>
             {
@@ -15,6 +16,7 @@
                 var track = ((string)parameters.track).Replace("해시", "#");
                 var trackMentions = (await mentions.GetAsync(track)).ToList();
                 var entries = trackMentions
+                    .Where(item => !ignoredUserNamesService.Get().Contains(item.UserMentionScreenName))
                     .GroupBy(mention => mention.UserMentionId)
                     .Select(g => new UserEntry
                     {

--- a/src/HashBus.WebApi/MostRetweetedModule.cs
+++ b/src/HashBus.WebApi/MostRetweetedModule.cs
@@ -7,7 +7,8 @@
 
     public class MostRetweetedModule : NancyModule
     {
-        public MostRetweetedModule(IRepository<string, IEnumerable<Retweetee>> tweets)
+        public MostRetweetedModule(
+            IRepository<string, IEnumerable<Retweetee>> tweets, IIgnoredUserNamesService ignoredUserNamesService)
         {
             this.Get["/most-retweeted/{track}", true] = async (parameters, __) =>
             {
@@ -15,6 +16,7 @@
                 var track = ((string)parameters.track).Replace("해시", "#");
                 var trackTweets = (await tweets.GetAsync(track)).ToList();
                 var entries = trackTweets
+                    .Where(item => !ignoredUserNamesService.Get().Contains(item.UserScreenName))
                     .GroupBy(tweet => tweet.UserId)
                     .Select(g => new UserEntry
                     {

--- a/src/HashBus.WebApi/Program.cs
+++ b/src/HashBus.WebApi/Program.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Configuration;
+    using System.Linq;
 
     class Program
     {
@@ -10,8 +11,11 @@
             var baseUri = new Uri(ConfigurationManager.AppSettings["BaseUri"]);
             var mongoConnectionString = ConfigurationManager.AppSettings["MongoConnectionString"];
             var mongoDBDatabase = ConfigurationManager.AppSettings["MongoDBDatabase"];
+            var ignoredUserNames = ConfigurationManager.AppSettings["IgnoredUserNames"]
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(userName => userName.Trim());
 
-            App.Run(baseUri, mongoConnectionString, mongoDBDatabase);
+            App.Run(baseUri, mongoConnectionString, mongoDBDatabase, ignoredUserNames);
         }
     }
 }

--- a/src/HashBus.WebApi/TopRetweetersModule.cs
+++ b/src/HashBus.WebApi/TopRetweetersModule.cs
@@ -7,7 +7,8 @@
 
     public class TopRetweetersModule : NancyModule
     {
-        public TopRetweetersModule(IRepository<string, IEnumerable<Retweet>> tweets)
+        public TopRetweetersModule
+            (IRepository<string, IEnumerable<Retweet>> tweets, IIgnoredUserNamesService ignoredUserNamesService)
         {
             this.Get["/top-retweeters/{track}", true] = async (parameters, __) =>
             {
@@ -15,6 +16,7 @@
                 var track = ((string)parameters.track).Replace("해시", "#");
                 var trackTweets = (await tweets.GetAsync(track)).ToList();
                 var entries = trackTweets
+                    .Where(item => !ignoredUserNamesService.Get().Contains(item.UserScreenName))
                     .GroupBy(tweet => tweet.UserId)
                     .Select(g => new UserEntry
                     {

--- a/src/HashBus.WebApi/TopTweetersModule.cs
+++ b/src/HashBus.WebApi/TopTweetersModule.cs
@@ -7,7 +7,8 @@
 
     public class TopTweetersModule : NancyModule
     {
-        public TopTweetersModule(IRepository<string, IEnumerable<Tweet>> tweets)
+        public TopTweetersModule(
+            IRepository<string, IEnumerable<Tweet>> tweets, IIgnoredUserNamesService ignoredUserNamesService)
         {
             this.Get["/top-tweeters/{track}", true] = async (parameters, __) =>
             {
@@ -15,6 +16,7 @@
                 var track = ((string)parameters.track).Replace("해시", "#");
                 var trackTweets = (await tweets.GetAsync(track)).ToList();
                 var entries = trackTweets
+                    .Where(item => !ignoredUserNamesService.Get().Contains(item.UserScreenName))
                     .GroupBy(tweet => tweet.UserId)
                     .Select(g => new UserEntry
                     {

--- a/src/HashBus.WebApi/TopTweetersRetweetersModule.cs
+++ b/src/HashBus.WebApi/TopTweetersRetweetersModule.cs
@@ -7,7 +7,8 @@
 
     public class TopTweetersRetweetersModule : NancyModule
     {
-        public TopTweetersRetweetersModule(IRepository<string, IEnumerable<TweetRetweet>> tweets)
+        public TopTweetersRetweetersModule(
+            IRepository<string, IEnumerable<TweetRetweet>> tweets, IIgnoredUserNamesService ignoredUserNamesService)
         {
             this.Get["/top-tweeters-retweeters/{track}", true] = async (parameters, __) =>
             {
@@ -15,6 +16,7 @@
                 var track = ((string)parameters.track).Replace("해시", "#");
                 var trackTweets = (await tweets.GetAsync(track)).ToList();
                 var entries = trackTweets
+                    .Where(item => !ignoredUserNamesService.Get().Contains(item.UserScreenName))
                     .GroupBy(tweet => tweet.UserId)
                     .Select(g => new UserEntry
                     {

--- a/src/HashBus.WebApi/app.config
+++ b/src/HashBus.WebApi/app.config
@@ -12,5 +12,6 @@
     <add key="BaseUri" value="http://localhost:13373" />
     <add key="MongoConnectionString" value="mongodb://localhost:27017" />
     <add key="MongoDBDatabase" value="hashbus_readmodel" />
+    <add key="IgnoredUserNames" value="adamralph,andreasohlund,danielmarbach,farmar,Indu_alagarsamy,janovesk,mat_mcloughlin,mauroservienti,michal_wojcik,sfeldman,UdiDahan" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
closes #120 

This ended up being a cherry pick of https://github.com/adamralph/HashBus/commit/093802400648f14b6f9a7308df807dcd3f9e1167 which was YOLO'd in during Build Stuff LT 2015, plus an amend to add all our staff who are attending NDC Oslo 2016 to the default config.

Using the config file, effectively, as a database, and filtering the results on the way out from the web API isn't a solution I'd recommend for a strategic app, but I think it's good enough for the purposes of HashBus.