### PR TITLE
Add GitVersion

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,2 @@
+assembly-versioning-scheme: Major
+next-version: 4

--- a/src/HashBus.Application.Commands/HashBus.Application.Commands.csproj
+++ b/src/HashBus.Application.Commands/HashBus.Application.Commands.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,5 +52,15 @@
     </Compile>
     <Compile Include="AnalyzeTweet.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Application.Commands/packages.config
+++ b/src/HashBus.Application.Commands/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.9" targetFramework="net451" />
 </packages>

--- a/src/HashBus.Application.Events/HashBus.Application.Events.csproj
+++ b/src/HashBus.Application.Events/HashBus.Application.Events.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,5 +46,15 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Application.Events/packages.config
+++ b/src/HashBus.Application.Events/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.9" targetFramework="net451" />
 </packages>

--- a/src/HashBus.Application/HashBus.Application.csproj
+++ b/src/HashBus.Application/HashBus.Application.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -97,4 +99,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Application/packages.config
+++ b/src/HashBus.Application/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net451" />

--- a/src/HashBus.NServiceBusConfiguration/HashBus.NServiceBusConfiguration.csproj
+++ b/src/HashBus.NServiceBusConfiguration/HashBus.NServiceBusConfiguration.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,6 +50,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HashBus.Projector.MostHashtagged/HashBus.Projector.MostHashtagged.csproj
+++ b/src/HashBus.Projector.MostHashtagged/HashBus.Projector.MostHashtagged.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.MostHashtagged/packages.config
+++ b/src/HashBus.Projector.MostHashtagged/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.Projector.MostMentioned/HashBus.Projector.MostMentioned.csproj
+++ b/src/HashBus.Projector.MostMentioned/HashBus.Projector.MostMentioned.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.MostMentioned/packages.config
+++ b/src/HashBus.Projector.MostMentioned/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.Projector.MostRetweeted/HashBus.Projector.MostRetweeted.csproj
+++ b/src/HashBus.Projector.MostRetweeted/HashBus.Projector.MostRetweeted.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.MostRetweeted/packages.config
+++ b/src/HashBus.Projector.MostRetweeted/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.Projector.TopRetweeters/HashBus.Projector.TopRetweeters.csproj
+++ b/src/HashBus.Projector.TopRetweeters/HashBus.Projector.TopRetweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.TopRetweeters/packages.config
+++ b/src/HashBus.Projector.TopRetweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.Projector.TopTweeters/HashBus.Projector.TopTweeters.csproj
+++ b/src/HashBus.Projector.TopTweeters/HashBus.Projector.TopTweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.TopTweeters/packages.config
+++ b/src/HashBus.Projector.TopTweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.Projector.TopTweetersRetweeters/HashBus.Projector.TopTweetersRetweeters.csproj
+++ b/src/HashBus.Projector.TopTweetersRetweeters/HashBus.Projector.TopTweetersRetweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,4 +100,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Projector.TopTweetersRetweeters/packages.config
+++ b/src/HashBus.Projector.TopTweetersRetweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.ReadModel.MongoDB/HashBus.ReadModel.MongoDB.csproj
+++ b/src/HashBus.ReadModel.MongoDB/HashBus.ReadModel.MongoDB.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,4 +69,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.ReadModel.MongoDB/packages.config
+++ b/src/HashBus.ReadModel.MongoDB/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />

--- a/src/HashBus.ReadModel/HashBus.ReadModel.csproj
+++ b/src/HashBus.ReadModel/HashBus.ReadModel.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,5 +46,15 @@
     <Compile Include="Tweet.cs" />
     <Compile Include="Mention.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.ReadModel/packages.config
+++ b/src/HashBus.ReadModel/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.9" targetFramework="net451" />
 </packages>

--- a/src/HashBus.Twitter.BackFill/HashBus.Twitter.BackFill.csproj
+++ b/src/HashBus.Twitter.BackFill/HashBus.Twitter.BackFill.csproj
@@ -81,6 +81,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HashBus.Twitter.BackFill/packages.config
+++ b/src/HashBus.Twitter.BackFill/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net451" />
   <package id="NServiceBus" version="5.2.9" targetFramework="net451" />

--- a/src/HashBus.Twitter.Monitor.CatchUp.Commands/HashBus.Twitter.Monitor.CatchUp.Commands.csproj
+++ b/src/HashBus.Twitter.Monitor.CatchUp.Commands/HashBus.Twitter.Monitor.CatchUp.Commands.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,7 +35,17 @@
   <ItemGroup>
     <Compile Include="StartCatchUp.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HashBus.Twitter.Monitor.CatchUp.Commands/packages.config
+++ b/src/HashBus.Twitter.Monitor.CatchUp.Commands/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.9" targetFramework="net451" />
 </packages>

--- a/src/HashBus.Twitter.Monitor.CatchUp/HashBus.Twitter.Monitor.CatchUp.csproj
+++ b/src/HashBus.Twitter.Monitor.CatchUp/HashBus.Twitter.Monitor.CatchUp.csproj
@@ -174,7 +174,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
   </Target>
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HashBus.Twitter.Monitor.CatchUp/packages.config
+++ b/src/HashBus.Twitter.Monitor.CatchUp/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net451" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net451" />

--- a/src/HashBus.Twitter.Monitor.Events/HashBus.Twitter.Monitor.Events.csproj
+++ b/src/HashBus.Twitter.Monitor.Events/HashBus.Twitter.Monitor.Events.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,5 +45,15 @@
   <ItemGroup>
     <Compile Include="TweetReceived.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Twitter.Monitor.Events/packages.config
+++ b/src/HashBus.Twitter.Monitor.Events/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.9" targetFramework="net451" />
 </packages>

--- a/src/HashBus.Twitter.Monitor.Simulator/HashBus.Twitter.Monitor.Simulator.csproj
+++ b/src/HashBus.Twitter.Monitor.Simulator/HashBus.Twitter.Monitor.Simulator.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -86,4 +88,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Twitter.Monitor.Simulator/packages.config
+++ b/src/HashBus.Twitter.Monitor.Simulator/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net451" />
   <package id="NServiceBus" version="5.2.9" targetFramework="net451" />

--- a/src/HashBus.Twitter.Monitor/HashBus.Twitter.Monitor.csproj
+++ b/src/HashBus.Twitter.Monitor/HashBus.Twitter.Monitor.csproj
@@ -164,5 +164,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
   </Target>
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
 </Project>

--- a/src/HashBus.Twitter.Monitor/app.config
+++ b/src/HashBus.Twitter.Monitor/app.config
@@ -10,8 +10,8 @@
   </UnicastBusConfig>
   <appSettings>
     <add key="Track" value="#Microsoft" />
-    <add key="NServiceBusConnectionString" value="Data Source=.\SqlExpress;Initial Catalog=HashBus.NServiceBus;Integrated Security=True"/>
-    <add key="EndpointName" value="HashBus.Twitter.Monitor"/>
+    <add key="NServiceBusConnectionString" value="Data Source=.\SqlExpress;Initial Catalog=HashBus.NServiceBus;Integrated Security=True" />
+    <add key="EndpointName" value="HashBus.Twitter.Monitor" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/HashBus.Twitter.Monitor/packages.config
+++ b/src/HashBus.Twitter.Monitor/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net451" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net451" />

--- a/src/HashBus.Viewer.MostHashtagged/HashBus.Viewer.MostHashtagged.csproj
+++ b/src/HashBus.Viewer.MostHashtagged/HashBus.Viewer.MostHashtagged.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -100,4 +102,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.MostHashtagged/packages.config
+++ b/src/HashBus.Viewer.MostHashtagged/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.MostMentioned/HashBus.Viewer.MostMentioned.csproj
+++ b/src/HashBus.Viewer.MostMentioned/HashBus.Viewer.MostMentioned.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -90,4 +92,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.MostMentioned/packages.config
+++ b/src/HashBus.Viewer.MostMentioned/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.MostRetweeted/HashBus.Viewer.MostRetweeted.csproj
+++ b/src/HashBus.Viewer.MostRetweeted/HashBus.Viewer.MostRetweeted.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -100,4 +102,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.MostRetweeted/packages.config
+++ b/src/HashBus.Viewer.MostRetweeted/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.Multiple/HashBus.Viewer.Multiple.csproj
+++ b/src/HashBus.Viewer.Multiple/HashBus.Viewer.Multiple.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -120,4 +122,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.Multiple/packages.config
+++ b/src/HashBus.Viewer.Multiple/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.TopRetweeters/HashBus.Viewer.TopRetweeters.csproj
+++ b/src/HashBus.Viewer.TopRetweeters/HashBus.Viewer.TopRetweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -100,4 +102,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.TopRetweeters/packages.config
+++ b/src/HashBus.Viewer.TopRetweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.TopTweeters/HashBus.Viewer.TopTweeters.csproj
+++ b/src/HashBus.Viewer.TopTweeters/HashBus.Viewer.TopTweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -100,4 +102,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.TopTweeters/packages.config
+++ b/src/HashBus.Viewer.TopTweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.Viewer.TopTweetersRetweeters/HashBus.Viewer.TopTweetersRetweeters.csproj
+++ b/src/HashBus.Viewer.TopTweetersRetweeters/HashBus.Viewer.TopTweetersRetweeters.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -100,4 +102,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.Viewer.TopTweetersRetweeters/packages.config
+++ b/src/HashBus.Viewer.TopTweetersRetweeters/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="Humanizer" version="1.37.7" targetFramework="net451" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/HashBus.WebApi/HashBus.WebApi.csproj
+++ b/src/HashBus.WebApi/HashBus.WebApi.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -110,4 +112,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.6.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/src/HashBus.WebApi/packages.config
+++ b/src/HashBus.WebApi/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColoredConsole" version="0.4.0" targetFramework="net451" />
+  <package id="GitVersionTask" version="3.6.2" targetFramework="net451" developmentDependency="true" />
   <package id="LiteGuard" version="0.10.0" targetFramework="net451" />
   <package id="MongoDB.Bson" version="2.1.0" targetFramework="net451" />
   <package id="MongoDB.Driver" version="2.1.0" targetFramework="net451" />


### PR DESCRIPTION
@Particular/hashbus-maintainers please review/merge.

Note that I've bumped to v4. Reason being:

- BuildStuff LT 2015: v1
- NDC Oslo 2016: v2
- NDC Sydney 2016: v3

I've also pushed tags for these on master.

I'm proposing the Chrome versioning scheme, i.e. major only, since it seems to make sense for apps (as opposed to libs).