### PR TITLE
Simulation never switches back to an upper case hashtag

### DIFF
--- a/src/HashBus.Twitter.Monitor.Simulator/Simulation.cs
+++ b/src/HashBus.Twitter.Monitor.Simulator/Simulation.cs
@@ -21,11 +21,19 @@ namespace HashBus.Twitter.Monitor.Simulator
                 var track = $"#{hashtag}";
                 var hashtagText = track;
                 var secondaryHashtag = new string(char.ConvertFromUtf32(random.Next(65, 80)).ElementAt(0), 6);
+
                 if (now.Millisecond % 3 == 0)
                 {
                     hashtag = hashtag.ToLowerInvariant();
                     hashtagText = hashtagText.ToLowerInvariant();
                     secondaryHashtag = secondaryHashtag.ToLowerInvariant();
+                }
+
+                if (now.Millisecond % 7 == 0)
+                {
+                    hashtag = hashtag.ToUpperInvariant();
+                    hashtagText = hashtagText.ToUpperInvariant();
+                    secondaryHashtag = secondaryHashtag.ToUpperInvariant();
                 }
 
                 var userId = random.Next(countOfUsers);


### PR DESCRIPTION
Each time the number of milliseconds is a multiple of 3, the casing of the hashtags is switched to lower, but there is no equivalent switch back to upper. This PR fixes that by switching the casing to upper each time the number of milliseconds is a multiple of 7 (less often on average).

@Particular/hashbus-maintainers please review/merge.