### PR TITLE
Show previous leader board when web API not available

### DIFF
--- a/src/HashBus.Viewer/LeaderboardView.cs
+++ b/src/HashBus.Viewer/LeaderboardView.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.Remoting;
     using System.Threading;
     using System.Threading.Tasks;
     using ColoredConsole;
@@ -89,15 +88,9 @@
                 {
                     currentLeaderboard = await leaderboards.GetAsync(track);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    ColorConsole.WriteLine(
-                        $"{DateTime.Now} ".DarkGray(),
-                        "Failed to get leaderboard. ".Red(),
-                        ex is ServerException ? "Could not communicate with the web API.".Yellow() : ex.Message.DarkRed());
-
-                    await Task.Delay(250);
-                    continue;
+                    currentLeaderboard = previousLeaderboard;
                 }
 
                 var lines = new List<IEnumerable<ColorToken>>();
@@ -140,11 +133,18 @@
                 }
 
                 var padding = new string(' ', horizontalPadding);
-                ColorConsole.WriteLine(
+                ColorConsole.Write(
                     padding,
                     $" {track} ".DarkCyan().On(ConsoleColor.White),
                     " ",
                     name.White());
+
+                if (currentLeaderboard == previousLeaderboard)
+                {
+                    ColorConsole.Write(" ", currentLeaderboard == previousLeaderboard ? " Service unavailable ".Yellow().OnRed() : "");
+                }
+
+                ColorConsole.WriteLine();
 
                 ColorConsole.WriteLine(
                     padding,


### PR DESCRIPTION
This is how it looks while the web API is unavailable. The message disappears when the web API becomes available again.

![image](https://user-images.githubusercontent.com/677704/36497157-c3d8e966-173a-11e8-9f15-3203a4a762f4.png)
